### PR TITLE
Add location-aware holiday checks

### DIFF
--- a/src/plugins/orangehrmLeavePlugin/Dao/HolidayDao.php
+++ b/src/plugins/orangehrmLeavePlugin/Dao/HolidayDao.php
@@ -97,15 +97,31 @@ class HolidayDao extends BaseDao
      * @param DateTime $date
      * @return Holiday|null
      */
-    public function getHolidayByDate(DateTime $date): ?Holiday
+    public function getHolidayByDate(DateTime $date, ?int $operationalCountryId = null): ?Holiday
     {
         $q = $this->createQueryBuilder(Holiday::class, 'holiday');
-        $q->andWhere($q->expr()->eq($q->expr()->substring('holiday.date', 6), ':datePortion'))
-            ->setParameter('datePortion', $date->format('m') . '-' . $date->format('d'));
-        $q->andWhere('holiday.recurring = :recurring')
-            ->setParameter('recurring', true);
-        $q->orWhere('holiday.date = :date')
+        $q->andWhere(
+            $q->expr()->orX(
+                $q->expr()->andX(
+                    $q->expr()->eq($q->expr()->substring('holiday.date', 6), ':datePortion'),
+                    $q->expr()->eq('holiday.recurring', ':recurring')
+                ),
+                $q->expr()->eq('holiday.date', ':date')
+            )
+        )
+            ->setParameter('datePortion', $date->format('m') . '-' . $date->format('d'))
+            ->setParameter('recurring', true)
             ->setParameter('date', $date);
+
+        if (!is_null($operationalCountryId)) {
+            $q->andWhere(
+                $q->expr()->orX(
+                    $q->expr()->isNull('holiday.operationalCountry'),
+                    $q->expr()->eq('IDENTITY(holiday.operationalCountry)', ':opCountry')
+                )
+            )
+                ->setParameter('opCountry', $operationalCountryId);
+        }
 
         return $this->fetchOne($q);
     }

--- a/src/plugins/orangehrmLeavePlugin/Service/HolidayService.php
+++ b/src/plugins/orangehrmLeavePlugin/Service/HolidayService.php
@@ -178,9 +178,9 @@ class HolidayService
      * @param DateTime $day
      * @return bool
      */
-    public function isHoliday(DateTime $day): bool
+    public function isHoliday(DateTime $day, ?int $operationalCountryId = null): bool
     {
-        $holiday = $this->getHolidayDao()->getHolidayByDate($day);
+        $holiday = $this->getHolidayDao()->getHolidayByDate($day, $operationalCountryId);
         if ($holiday != null && $holiday->getLength() == Holiday::HOLIDAY_FULL_DAY_LENGTH) {
             return true;
         }
@@ -191,9 +191,9 @@ class HolidayService
      * @param DateTime $day
      * @return bool
      */
-    public function isHalfDay(DateTime $day): bool
+    public function isHalfDay(DateTime $day, ?int $operationalCountryId = null): bool
     {
-        $holiday = $this->getHolidayDao()->getHolidayByDate($day);
+        $holiday = $this->getHolidayDao()->getHolidayByDate($day, $operationalCountryId);
         if ($holiday != null &&
             $holiday->getLength() >= WorkWeek::WORKWEEK_LENGTH_HALF_DAY &&
             $holiday->getLength() < $this->getConfigService()->getDefaultWorkShiftLength()) {
@@ -206,9 +206,9 @@ class HolidayService
      * @param DateTime $day
      * @return bool
      */
-    public function isHalfDayHoliday(DateTime $day): bool
+    public function isHalfDayHoliday(DateTime $day, ?int $operationalCountryId = null): bool
     {
-        $holiday = $this->getHolidayDao()->getHolidayByDate($day);
+        $holiday = $this->getHolidayDao()->getHolidayByDate($day, $operationalCountryId);
         if ($holiday != null && $holiday->getLength() == Holiday::HOLIDAY_HALF_DAY_LENGTH) {
             return true;
         }

--- a/src/plugins/orangehrmLeavePlugin/WorkSchedule/BasicWorkSchedule.php
+++ b/src/plugins/orangehrmLeavePlugin/WorkSchedule/BasicWorkSchedule.php
@@ -21,8 +21,10 @@ namespace OrangeHRM\Leave\WorkSchedule;
 use DateTime;
 use OrangeHRM\Admin\Dto\WorkShiftStartAndEndTime;
 use OrangeHRM\Admin\Service\WorkShiftService;
+use OrangeHRM\Core\Traits\ORM\EntityManagerTrait;
 use OrangeHRM\Core\Traits\Service\ConfigServiceTrait;
 use OrangeHRM\Entity\EmployeeWorkShift;
+use OrangeHRM\Entity\OperationalCountry;
 use OrangeHRM\Leave\Traits\Service\HolidayServiceTrait;
 use OrangeHRM\Leave\Traits\Service\WorkWeekServiceTrait;
 use OrangeHRM\Pim\Traits\Service\EmployeeServiceTrait;
@@ -33,6 +35,7 @@ class BasicWorkSchedule implements WorkScheduleInterface
     use WorkWeekServiceTrait;
     use HolidayServiceTrait;
     use ConfigServiceTrait;
+    use EntityManagerTrait;
 
     /**
      * @var int|null
@@ -105,6 +108,31 @@ class BasicWorkSchedule implements WorkScheduleInterface
     }
 
     /**
+     * Get operational country id for current employee
+     *
+     * @return int|null
+     */
+    protected function getOperationalCountryId(): ?int
+    {
+        if (is_null($this->empNumber)) {
+            return null;
+        }
+
+        $employee = $this->getEmployeeService()->getEmployeeByEmpNumber($this->empNumber);
+        foreach ($employee->getLocations() as $location) {
+            $country = $location->getCountry();
+            $operationalCountry = $this->getEntityManager()
+                ->getRepository(OperationalCountry::class)
+                ->findOneBy(['country' => $country]);
+            if ($operationalCountry instanceof OperationalCountry) {
+                return $operationalCountry->getId();
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @inheritDoc
      */
     public function isNonWorkingDay(DateTime $day, bool $fullDay): bool
@@ -117,7 +145,7 @@ class BasicWorkSchedule implements WorkScheduleInterface
      */
     public function isHalfDay(DateTime $day): bool
     {
-        return $this->getHolidayService()->isHalfDay($day);
+        return $this->getHolidayService()->isHalfDay($day, $this->getOperationalCountryId());
     }
 
     /**
@@ -125,7 +153,7 @@ class BasicWorkSchedule implements WorkScheduleInterface
      */
     public function isHoliday(DateTime $day): bool
     {
-        return $this->getHolidayService()->isHoliday($day);
+        return $this->getHolidayService()->isHoliday($day, $this->getOperationalCountryId());
     }
 
     /**
@@ -133,6 +161,6 @@ class BasicWorkSchedule implements WorkScheduleInterface
      */
     public function isHalfDayHoliday(DateTime $day): bool
     {
-        return $this->getHolidayService()->isHalfDayHoliday($day);
+        return $this->getHolidayService()->isHalfDayHoliday($day, $this->getOperationalCountryId());
     }
 }


### PR DESCRIPTION
## Summary
- update HolidayDao to filter by operational country
- update HolidayService methods to accept country context
- use employee's location in BasicWorkSchedule when determining holidays

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68550a74edc4832986ae67d3fe93bcf7