### PR TITLE
Fix domain env variable for calendar link

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,6 +98,7 @@ pipeline {
                     def dbNameId = "ohrm_db_name_${envPrefix}"
 
                     def calendarTokenId = "ohrm_calendar_access_token_${envPrefix}"
+                    def domainId = "ohrm_domain_${envPrefix}"
 
                     def envCredentials = [
                         usernamePassword(credentialsId: dbCredsId, usernameVariable: 'DB_USER', passwordVariable: 'DB_PASS'),
@@ -105,7 +106,8 @@ pipeline {
                         string(credentialsId: dbNameId, variable: 'DB_NAME'),
                         string(credentialsId: 'ohrm_cookie_domain', variable: 'COOKIE_DOMAIN'),
                         string(credentialsId: 'CF_APP_LAUNCHER_URL', variable: 'CF_APP_URL'),
-                        string(credentialsId: calendarTokenId, variable: 'CALENDAR_ACCESS_TOKEN')
+                        string(credentialsId: calendarTokenId, variable: 'CALENDAR_ACCESS_TOKEN'),
+                        string(credentialsId: domainId, variable: 'CALENDAR_DOMAIN')
                     ]
 
                     withCredentials(envCredentials) {
@@ -118,6 +120,7 @@ pipeline {
                         CF_LAUNCHER="${CF_APP_URL}"
                         COOKIE_DOMAIN="${COOKIE_DOMAIN}"
                         CALENDAR_ACCESS_TOKEN="${CALENDAR_ACCESS_TOKEN}"
+                        CALENDAR_DOMAIN="${CALENDAR_DOMAIN}"
                     """.stripIndent()
 
                         writeFile file: '.env.generated', text: envContent

--- a/web/leave-calendar.php
+++ b/web/leave-calendar.php
@@ -10,7 +10,7 @@ function requireEnv(string $key): string {
 }
 
 $token = requireEnv('CALENDAR_ACCESS_TOKEN');
-$host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$host = requireEnv('CALENDAR_DOMAIN');
 
 $leaveTypeColors = [
     'Annual leave' => '#1abc9c',


### PR DESCRIPTION
## Summary
- pull `CALENDAR_DOMAIN` from env in Leave Calendar
- pass CALENDAR_DOMAIN via Jenkins credentials

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_b_686033ed625c832991a7ad092af52272