### PR TITLE
Normalize Unpaid Leave

### DIFF
--- a/web/leave-calendar-subscription.php
+++ b/web/leave-calendar-subscription.php
@@ -83,6 +83,13 @@ function locationToTimezone(?string $location): string {
         : 'Asia/Hong_Kong';
 }
 
+function normalizeLeaveType(string $type): string {
+    $map = [
+        'Unpaid Leave' => 'Annual leave',
+    ];
+    return $map[$type] ?? $type;
+}
+
 $leaveTypeColors = [
     'Annual leave' => '#1abc9c',
     'Birthday Leave' => '#3498db',
@@ -98,7 +105,6 @@ $leaveTypeColors = [
     'Sick Leave (paid by company)' => '#34495e',
     'Sick Leave (paid by Social Ins Dept)' => '#c0392b',
     'Time-off in Lieu' => '#27ae60',
-    'Unpaid Leave' => '#7f8c8d',
     'Work from home' => '#95a5a6'
 ];
 $unapprovedColor = '#bdc3c7';
@@ -108,7 +114,8 @@ $current = null;
 foreach ($rows as $row) {
     $date = new DateTime($row['date']);
     $timezone = locationToTimezone($row['location_name'] ?? null);
-    $color = $leaveTypeColors[$row['leave_type']] ?? '#cccccc';
+    $leaveType = normalizeLeaveType($row['leave_type']);
+    $color = $leaveTypeColors[$leaveType] ?? '#cccccc';
     if (!in_array($row['status'], [2,3])) {
         $color = $unapprovedColor;
     }
@@ -129,7 +136,7 @@ foreach ($rows as $row) {
             'end' => $end,
             'allDay' => true,
             'color' => $color,
-            'leaveType' => $row['leave_type'],
+            'leaveType' => $leaveType,
             'timezone' => $timezone
         ];
         $events[] = $event;
@@ -143,7 +150,7 @@ foreach ($rows as $row) {
             'end' => $end,
             'allDay' => false,
             'color' => $color,
-            'leaveType' => $row['leave_type'],
+            'leaveType' => $leaveType,
             'timezone' => $timezone
         ];
         unset($current);

--- a/web/leave-calendar.php
+++ b/web/leave-calendar.php
@@ -27,7 +27,6 @@ $leaveTypeColors = [
     'Sick Leave (paid by company)' => '#34495e',
     'Sick Leave (paid by Social Ins Dept)' => '#c0392b',
     'Time-off in Lieu' => '#27ae60',
-    'Unpaid Leave' => '#7f8c8d',
     'Work from home' => '#95a5a6'
 ];
 $unapprovedColor = '#bdc3c7';


### PR DESCRIPTION
## Summary
- handle "Unpaid Leave" with `normalizeLeaveType()`
- use Annual leave color for Unpaid Leave
- normalize leave type when building calendar events

## Testing
- `npm test` *(fails: Missing script and network access blocked)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e9d9e8ebc83299b2f0a369d03353d