### PR TITLE
Add event status to calendar exports

### DIFF
--- a/web/leave-calendar-subscription.php
+++ b/web/leave-calendar-subscription.php
@@ -2,6 +2,9 @@
 // Load environment variables
 $_ENV = parse_ini_file(__DIR__ . '/../shared/.env') ?: [];
 
+require_once __DIR__ . '/../src/plugins/orangehrmLeavePlugin/entity/Leave.php';
+use OrangeHRM\Entity\Leave;
+
 function requireEnv(string $key): string {
     if (!isset($_ENV[$key]) || $_ENV[$key] === '') {
         http_response_code(500);
@@ -112,6 +115,9 @@ foreach ($rows as $row) {
     if (!in_array($row['status'], [2,3])) {
         $color = $unapprovedColor;
     }
+    $status = in_array($row['status'], [Leave::LEAVE_STATUS_LEAVE_APPROVED, Leave::LEAVE_STATUS_LEAVE_TAKEN])
+        ? 'CONFIRMED'
+        : 'TENTATIVE';
     $fullDay = $row['duration_type'] == 0 || (isset($row['length_hours']) && (float)$row['length_hours'] >= 8);
     if ($fullDay) {
         if ($current &&
@@ -130,7 +136,8 @@ foreach ($rows as $row) {
             'allDay' => true,
             'color' => $color,
             'leaveType' => $row['leave_type'],
-            'timezone' => $timezone
+            'timezone' => $timezone,
+            'status' => $status
         ];
         $events[] = $event;
         $current = &$events[array_key_last($events)];
@@ -144,7 +151,8 @@ foreach ($rows as $row) {
             'allDay' => false,
             'color' => $color,
             'leaveType' => $row['leave_type'],
-            'timezone' => $timezone
+            'timezone' => $timezone,
+            'status' => $status
         ];
         unset($current);
         $current = null;
@@ -188,6 +196,7 @@ function eventsToIcs(array $events): string {
             $ics .= 'DTSTART;TZID=' . $tz . ':' . $event['start']->format('Ymd\THis') . "\r\n";
             $ics .= 'DTEND;TZID=' . $tz . ':' . $event['end']->format('Ymd\THis') . "\r\n";
         }
+        $ics .= 'STATUS:' . $event['status'] . "\r\n";
         $ics .= "CLASS:PUBLIC\r\n";
         $ics .= "TRANSP:OPAQUE\r\n";
         $ics .= "END:VEVENT\r\n";
@@ -206,7 +215,8 @@ if ($format === 'json') {
             'allDay' => $e['allDay'],
             'color' => $e['color'],
             'leaveType' => $e['leaveType'],
-            'timezone' => $e['timezone']
+            'timezone' => $e['timezone'],
+            'status' => $e['status']
         ];
     }, $events);
     echo json_encode($data);


### PR DESCRIPTION
## Summary
- include Leave constants for status handling in `leave-calendar-subscription.php`
- add status field to event objects
- output event status in ICS feed
- expose status via JSON export

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686e9dcac9d0832988a13ac260df9d37