### PR TITLE
Fix ICS subscription script autoload

### DIFF
--- a/web/leave-calendar-subscription.php
+++ b/web/leave-calendar-subscription.php
@@ -2,7 +2,9 @@
 // Load environment variables
 $_ENV = parse_ini_file(__DIR__ . '/../shared/.env') ?: [];
 
-require_once __DIR__ . '/../src/plugins/orangehrmLeavePlugin/entity/Leave.php';
+// Autoload dependencies so we can access entity constants
+require __DIR__ . '/../src/vendor/autoload.php';
+
 use OrangeHRM\Entity\Leave;
 
 function requireEnv(string $key): string {


### PR DESCRIPTION
## Summary
- autoload dependencies in `leave-calendar-subscription.php` to allow use of the Leave entity

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_686f09dfe3c4832985dbb75f9f3cdb1e