### PR TITLE
Use leave id for calendar event UID

### DIFF
--- a/web/leave-calendar-subscription.php
+++ b/web/leave-calendar-subscription.php
@@ -159,6 +159,7 @@ foreach ($rows as $row) {
         }
         $end = (clone $date)->modify('+1 day');
         $event = [
+            'id' => $row['id'],
             'request' => $row['leave_request_id'],
             'title' => $name,
             'emoji' => $emoji,
@@ -178,6 +179,7 @@ foreach ($rows as $row) {
         $start = DateTime::createFromFormat('Y-m-d H:i:s', $row['date'] . ' ' . $row['start_time']);
         $end = DateTime::createFromFormat('Y-m-d H:i:s', $row['date'] . ' ' . $row['end_time']);
         $events[] = [
+            'id' => $row['id'],
             'title' => $name,
             'emoji' => $emoji,
             'summary' => trim($name . ' ' . $emoji),
@@ -217,7 +219,7 @@ function eventsToIcs(array $events): string {
         $ics .= "END:VTIMEZONE\r\n";
     }
     foreach ($events as $idx => $event) {
-        $uid = 'leave-' . $idx . '@orangehrm';
+        $uid = 'leave-' . ($event['id'] ?? $idx) . '@orangehrm';
         $ics .= "BEGIN:VEVENT\r\n";
         $ics .= 'UID:' . $uid . "\r\n";
         $summary = $event['summary'] ?? $event['title'];


### PR DESCRIPTION
## Summary
- add `id` to full/partial leave events
- build iCal UID from the event's id

## Testing
- `php -l web/leave-calendar-subscription.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686fcb6c4f408329a630f5d78f351c5a