### PR TITLE
Add debug flag for leave calendar pages

### DIFF
--- a/web/leave-calendar-subscription.php
+++ b/web/leave-calendar-subscription.php
@@ -1,6 +1,10 @@
 <?php
 // Load environment variables
 $_ENV = parse_ini_file(__DIR__ . '/../shared/.env') ?: [];
+if (isset($_GET['debug']) && $_GET['debug'] === 'true') {
+    error_reporting(E_ALL);
+    ini_set('display_errors', 'On');
+}
 
 // Autoload dependencies so we can access entity constants
 require __DIR__ . '/../src/vendor/autoload.php';

--- a/web/leave-calendar.php
+++ b/web/leave-calendar.php
@@ -1,5 +1,9 @@
 <?php
 $_ENV = parse_ini_file(__DIR__ . '/../shared/.env') ?: [];
+if (isset($_GET['debug']) && $_GET['debug'] === 'true') {
+    error_reporting(E_ALL);
+    ini_set('display_errors', 'On');
+}
 
 function requireEnv(string $key): string {
     if (!isset($_ENV[$key]) || $_ENV[$key] === '') {

--- a/web/sso-login.php
+++ b/web/sso-login.php
@@ -2,6 +2,11 @@
 // --- Load .env securely ---
 $_ENV = parse_ini_file(__DIR__ . '/../shared/.env') ?: [];
 
+if (isset($_GET['debug']) && $_GET['debug'] === 'true') {
+    error_reporting(E_ALL);
+    ini_set('display_errors', 'On');
+}
+
 // --- Secure env var helper ---
 function requireEnv(string $key): string {
     if (!isset($_ENV[$key]) || $_ENV[$key] === '') {
@@ -24,10 +29,6 @@ session_set_cookie_params([
     'httponly' => true,
     'samesite' => 'None'
 ]);
-
-// Enable debugging
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
 
 // Autoload Composer dependencies
 require __DIR__ . '/../src/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- allow `debug=true` param to show PHP warnings in leave calendar pages

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686fde549b508329a06b0d19f7f96c0a