### PR TITLE
Fix color for timed events and add tooltips

### DIFF
--- a/src/plugins/orangehrmCorePlugin/Service/MenuService.php
+++ b/src/plugins/orangehrmCorePlugin/Service/MenuService.php
@@ -188,6 +188,18 @@ class MenuService
                 $selectedSidePanelMenuId = $detailedSidePanelMenuItem->getId();
             }
             $normalizedSidePanelMenuItems[] = $this->normalizeMenuItem($detailedSidePanelMenuItem, $baseUrl, $active);
+
+            // Insert custom Leave Calendar link after Leave
+            if ($detailedSidePanelMenuItem->getMenuTitle() === 'Leave') {
+                $leaveCalendar = new DetailedMenuItem();
+                $leaveCalendar->setId(9999);
+                $leaveCalendar->setMenuTitle('Leave Calendar');
+                $leaveCalendar->setAdditionalParams([
+                    'icon' => 'leave',
+                    'url' => '/web/leave-calendar.php',
+                ]);
+                $normalizedSidePanelMenuItems[] = $this->normalizeMenuItem($leaveCalendar, $baseUrl, false);
+            }
         }
 
         $normalizedTopMenuItems = [];

--- a/web/leave-calendar.php
+++ b/web/leave-calendar.php
@@ -97,6 +97,8 @@ const calendar = new FullCalendar.Calendar(calendarEl, {
     data.backgroundColor = color;
     data.borderColor = color;
     data.textColor = approved ? '#fff' : '#000';
+    // force block display so timed events in month view show background color
+    data.display = 'block';
     return data;
   },
   eventOverlap: false,
@@ -117,6 +119,20 @@ const calendar = new FullCalendar.Calendar(calendarEl, {
     }
     div.textContent = text;
     return { domNodes: [div] };
+  },
+  eventDidMount: function(info) {
+    const name = info.event.title;
+    const type = info.event.extendedProps.leaveType || '';
+    const normalized = normalizeLeaveType(type);
+    const emoji = leaveTypeEmoji[normalized] || '';
+    let timePart = '';
+    if (!info.event.allDay) {
+      const opts = { hour: '2-digit', minute: '2-digit' };
+      const startStr = info.event.start.toLocaleTimeString([], opts);
+      const endStr = info.event.end.toLocaleTimeString([], opts);
+      timePart = startStr + ' - ' + endStr + ' ';
+    }
+    info.el.title = timePart + name + (emoji ? ' ' + emoji : '');
   }
 });
 calendar.render();

--- a/web/leave-calendar.php
+++ b/web/leave-calendar.php
@@ -124,15 +124,13 @@ const calendar = new FullCalendar.Calendar(calendarEl, {
     const name = info.event.title;
     const type = info.event.extendedProps.leaveType || '';
     const normalized = normalizeLeaveType(type);
-    const emoji = leaveTypeEmoji[normalized] || '';
-    let timePart = '';
+    let tooltip = name + ' - ' + normalized;
     if (!info.event.allDay) {
       const opts = { hour: '2-digit', minute: '2-digit' };
       const startStr = info.event.start.toLocaleTimeString([], opts);
       const endStr = info.event.end.toLocaleTimeString([], opts);
-      timePart = startStr + ' - ' + endStr + ' ';
+      tooltip += ' ' + startStr + ' - ' + endStr;
     }
-    const tooltip = timePart + name + (emoji ? ' ' + emoji : '');
     info.el.setAttribute('title', tooltip);
   }
 });

--- a/web/leave-calendar.php
+++ b/web/leave-calendar.php
@@ -132,7 +132,8 @@ const calendar = new FullCalendar.Calendar(calendarEl, {
       const endStr = info.event.end.toLocaleTimeString([], opts);
       timePart = startStr + ' - ' + endStr + ' ';
     }
-    info.el.title = timePart + name + (emoji ? ' ' + emoji : '');
+    const tooltip = timePart + name + (emoji ? ' ' + emoji : '');
+    info.el.setAttribute('title', tooltip);
   }
 });
 calendar.render();


### PR DESCRIPTION
## Summary
- ensure timed events are rendered as colored blocks
- add tooltip showing leave details on hover

## Testing
- `php -l web/leave-calendar.php`

------
https://chatgpt.com/codex/tasks/task_b_687104d73a8483299ae168b0f28adfb0