### PR TITLE
Add leave-calendar2 page

### DIFF
--- a/web/leave-calendar2.php
+++ b/web/leave-calendar2.php
@@ -43,20 +43,33 @@ $leaveTypeEmoji = [
 ];
 
 $subscribeUrl = 'https://' . $host . '/web/leave-calendar.php?access_token=' . urlencode($token);
+
+$baseUrl = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
+$publicPath = $baseUrl;
+$sidePanelMenuItems = [
+    ['label' => 'Dashboard', 'url' => $baseUrl . '/index.php'],
+    ['label' => 'Leave', 'url' => $baseUrl . '/leave/viewLeaveList'],
+];
+$userInfo = [
+    'firstName' => 'User',
+    'lastName' => 'Demo',
+    'profImgSrc' => $publicPath . '/images/default-photo.png',
+    'hasPassword' => false,
+];
 ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="icon" href="dist/favicon.ico">
-<link href="dist/css/chunk-vendors.css" rel="preload" as="style">
-<link href="dist/css/app.css" rel="preload" as="style">
-<link href="dist/js/chunk-vendors.js" rel="preload" as="script">
-<link href="dist/js/app.js" rel="preload" as="script">
+<link rel="icon" href="<?= $publicPath ?>/dist/favicon.ico">
+<link href="<?= $publicPath ?>/dist/css/chunk-vendors.css" rel="preload" as="style">
+<link href="<?= $publicPath ?>/dist/css/app.css" rel="preload" as="style">
+<link href="<?= $publicPath ?>/dist/js/chunk-vendors.js" rel="preload" as="script">
+<link href="<?= $publicPath ?>/dist/js/app.js" rel="preload" as="script">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.css">
-<link href="dist/css/chunk-vendors.css" rel="stylesheet"/>
-<link href="dist/css/app.css" rel="stylesheet"/>
+<link href="<?= $publicPath ?>/dist/css/chunk-vendors.css" rel="stylesheet"/>
+<link href="<?= $publicPath ?>/dist/css/app.css" rel="stylesheet"/>
 <style>
   body { font-family: Arial, sans-serif; padding: 20px; }
   .header { display: flex; align-items: center; justify-content: space-between; max-width: 900px; margin: 0 auto; }
@@ -68,9 +81,11 @@ $subscribeUrl = 'https://' . $host . '/web/leave-calendar.php?access_token=' . u
 <div id="app">
 <oxd-layout
     home-url="/"
-    :sidepanel-menu-items="[]"
+    :sidepanel-menu-items='<?= json_encode($sidePanelMenuItems) ?>'
     :topbar-menu-items="[]"
-    :user="{}"
+    :user='<?= json_encode($userInfo) ?>'
+    brand-logo-src="<?= $publicPath ?>/images/ohrm_logo.png"
+    brand-banner-src="<?= $publicPath ?>/images/ohrm_branding.png"
     logout-url="#"
     support-url="#"
     :update-password-url="null"
@@ -102,10 +117,13 @@ $subscribeUrl = 'https://' . $host . '/web/leave-calendar.php?access_token=' . u
 </oxd-layout>
 </div>
 <script type="text/javascript">
-  window.appGlobal = { baseUrl: '', publicPath: '' };
+  window.appGlobal = {
+    baseUrl: <?= json_encode($baseUrl) ?>,
+    publicPath: <?= json_encode($publicPath) ?>
+  };
 </script>
-<script src="dist/js/chunk-vendors.js"></script>
-<script src="dist/js/app.js"></script>
+<script src="<?= $publicPath ?>/dist/js/chunk-vendors.js"></script>
+<script src="<?= $publicPath ?>/dist/js/app.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.js"></script>
 <script>
 const leaveTypeEmoji = <?= json_encode($leaveTypeEmoji) ?>;
@@ -124,7 +142,7 @@ const calendar = new FullCalendar.Calendar(calendarEl, {
   height: 'auto',
   slotMinTime: '08:00:00',
   slotMaxTime: '19:00:00',
-  events: 'leave-calendar-subscription.php?access_token=<?= urlencode($token) ?>&format=json',
+  events: window.appGlobal.baseUrl + '/leave-calendar-subscription.php?access_token=<?= urlencode($token) ?>&format=json',
   eventDataTransform: function(data) {
     const approved = data.status === 'CONFIRMED';
     const color = approved ? '#2ecc71' : '#bdc3c7';

--- a/web/leave-calendar2.php
+++ b/web/leave-calendar2.php
@@ -1,0 +1,174 @@
+<?php
+$_ENV = parse_ini_file(__DIR__ . '/../shared/.env')
+    ?: parse_ini_file(__DIR__ . '/../.env')
+    ?: [];
+if (isset($_GET['debug']) && $_GET['debug'] === 'true') {
+    error_reporting(E_ALL);
+    ini_set('display_errors', 'On');
+}
+
+function requireEnv(string $key): string {
+    if (!isset($_ENV[$key]) || $_ENV[$key] === '') {
+        http_response_code(500);
+        exit("Missing required environment variable: $key");
+    }
+    return $_ENV[$key];
+}
+
+function normalizeLeaveType(string $type): string {
+    $lower = strtolower($type);
+    if (strpos($lower, 'annual') !== false) {
+        return 'Annual leave';
+    }
+    if (strpos($lower, 'sick') !== false) {
+        return 'Sick Leave';
+    }
+    if (strpos($lower, 'work from home') !== false) {
+        return 'Work from home';
+    }
+    if (strpos($lower, 'travel') !== false) {
+        return 'Travel';
+    }
+    return $type;
+}
+
+$token = requireEnv('CALENDAR_ACCESS_TOKEN');
+$host = requireEnv('CALENDAR_DOMAIN');
+
+$leaveTypeEmoji = [
+    'Annual leave' => '🏖️',
+    'Sick Leave' => '🤒',
+    'Work from home' => '🏡',
+    'Travel' => '✈️'
+];
+
+$subscribeUrl = 'https://' . $host . '/web/leave-calendar.php?access_token=' . urlencode($token);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" href="dist/favicon.ico">
+<link href="dist/css/chunk-vendors.css" rel="preload" as="style">
+<link href="dist/css/app.css" rel="preload" as="style">
+<link href="dist/js/chunk-vendors.js" rel="preload" as="script">
+<link href="dist/js/app.js" rel="preload" as="script">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.css">
+<link href="dist/css/chunk-vendors.css" rel="stylesheet"/>
+<link href="dist/css/app.css" rel="stylesheet"/>
+<style>
+  body { font-family: Arial, sans-serif; padding: 20px; }
+  .header { display: flex; align-items: center; justify-content: space-between; max-width: 900px; margin: 0 auto; }
+  #calendar { max-width: 900px; margin: 20px auto; }
+  .subscribe { max-width: 900px; margin: 20px auto; }
+</style>
+</head>
+<body>
+<div id="app">
+<oxd-layout
+    home-url="/"
+    :sidepanel-menu-items="[]"
+    :topbar-menu-items="[]"
+    :user="{}"
+    logout-url="#"
+    support-url="#"
+    :update-password-url="null"
+    :permissions="[]"
+    :breadcrumb="[]"
+    :date-format="[]"
+    help-url="#"
+    :show-upgrade="false"
+>
+  <div class="header">
+    <h2>Leave Calendar</h2>
+  </div>
+  <div id="calendar"></div>
+  <div class="subscribe">
+    <h3>Subscribe to Leave Calendar</h3>
+    <ol>
+      <li>Visit <a href="https://outlook.office.com/calendar">https://outlook.office.com/calendar</a></li>
+      <li>Choose <strong>Add Calendar</strong></li>
+      <li>Select <strong>Subscribe from web</strong></li>
+      <li>Paste <code><?= htmlspecialchars($subscribeUrl, ENT_QUOTES) ?></code></li>
+      <li>Optional: Select the calendar in Outlook Desktop</li>
+    </ol>
+  </div>
+  <template v-slot:footer>
+    <div class="orangehrm-footer">
+      &copy; <?= date('Y') ?> <a href="http://www.orangehrm.com" target="_blank">OrangeHRM, Inc</a>. All rights reserved.
+    </div>
+</template>
+</oxd-layout>
+</div>
+<script type="text/javascript">
+  window.appGlobal = { baseUrl: '', publicPath: '' };
+</script>
+<script src="dist/js/chunk-vendors.js"></script>
+<script src="dist/js/app.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.js"></script>
+<script>
+const leaveTypeEmoji = <?= json_encode($leaveTypeEmoji) ?>;
+function normalizeLeaveType(type) {
+  const lower = type.toLowerCase();
+  if (lower.includes('annual')) return 'Annual leave';
+  if (lower.includes('sick')) return 'Sick Leave';
+  if (lower.includes('work from home')) return 'Work from home';
+  if (lower.includes('travel')) return 'Travel';
+  return type;
+}
+const calendarEl = document.getElementById('calendar');
+const calendar = new FullCalendar.Calendar(calendarEl, {
+  initialView: 'dayGridMonth',
+  headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek' },
+  height: 'auto',
+  slotMinTime: '08:00:00',
+  slotMaxTime: '19:00:00',
+  events: 'leave-calendar-subscription.php?access_token=<?= urlencode($token) ?>&format=json',
+  eventDataTransform: function(data) {
+    const approved = data.status === 'CONFIRMED';
+    const color = approved ? '#2ecc71' : '#bdc3c7';
+    data.backgroundColor = color;
+    data.borderColor = color;
+    data.textColor = approved ? '#fff' : '#000';
+    // force block display so timed events in month view show background color
+    data.display = 'block';
+    return data;
+  },
+  eventOverlap: false,
+  eventContent: function(arg) {
+    const name = arg.event.title;
+    const type = arg.event.extendedProps.leaveType || '';
+    const normalized = normalizeLeaveType(type);
+    const emoji = leaveTypeEmoji[normalized] || '';
+    const div = document.createElement('div');
+    if (arg.view.type === 'dayGridMonth' || arg.view.type === 'timeGridWeek') {
+      div.style.whiteSpace = 'normal';
+      div.style.overflowWrap = 'anywhere';
+    }
+    let text = name + (emoji ? ' ' + emoji : '');
+    if (arg.view.type !== 'dayGridMonth' && arg.view.type !== 'timeGridWeek') {
+      const timeText = arg.timeText ? arg.timeText + ' ' : '';
+      text = timeText + text;
+    }
+    div.textContent = text;
+    return { domNodes: [div] };
+  },
+  eventDidMount: function(info) {
+    const name = info.event.title;
+    const type = info.event.extendedProps.leaveType || '';
+    const normalized = normalizeLeaveType(type);
+    let tooltip = name + ' - ' + normalized;
+    if (!info.event.allDay) {
+      const opts = { hour: '2-digit', minute: '2-digit' };
+      const startStr = info.event.start.toLocaleTimeString([], opts);
+      const endStr = info.event.end.toLocaleTimeString([], opts);
+      tooltip += ' ' + startStr + ' - ' + endStr;
+    }
+    info.el.setAttribute('title', tooltip);
+  }
+});
+calendar.render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `leave-calendar2.php` as a new page
- wrap calendar page with OrangeHRM layout assets

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687123a4e27483299522587f6fb62d7f