### PR TITLE
Add breadcrumb to leave calendar

### DIFF
--- a/web/leave-calendar.php
+++ b/web/leave-calendar.php
@@ -59,7 +59,7 @@ $subscribeUrl = 'webcal://' . $host . '/web/leave-calendar.php?access_token=' . 
 </head>
 <body>
 <div class="header">
-  <h2>Leave Calendar</h2>
+  <h2><a href="/web/leave/viewLeaveList">Leave</a> &gt; Leave Calendar</h2>
 </div>
 <div id="calendar"></div>
 <div class="subscribe">


### PR DESCRIPTION
## Summary
- add link back to leave list via breadcrumb on Leave Calendar page

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68713730fb9c8329a4e4a5cb05105019