### PR TITLE
Fix leave calendar header on mobile

### DIFF
--- a/web/leave-calendar.php
+++ b/web/leave-calendar.php
@@ -55,6 +55,19 @@ $subscribeUrl = 'webcal://' . $host . '/web/leave-calendar-subscription.php?acce
   .header { display: flex; align-items: center; justify-content: space-between; max-width: 900px; margin: 0 auto; }
   #calendar { max-width: 900px; margin: 20px auto; }
   .subscribe { max-width: 900px; margin: 20px auto; }
+
+  /* Better alignment for FullCalendar header on small screens */
+  @media (max-width: 600px) {
+    .fc-header-toolbar {
+      flex-direction: column;
+      align-items: center;
+    }
+    .fc-header-toolbar .fc-toolbar-chunk {
+      width: 100%;
+      margin-bottom: 8px;
+      text-align: center;
+    }
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- improve responsive layout for calendar header on small screens

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871a87342d88329a548c36d13a5420b