### PR TITLE
Add link to leave request in supervisor email

### DIFF
--- a/src/plugins/orangehrmLeavePlugin/Mail/Processor/LeaveAllocateEmailProcessor.php
+++ b/src/plugins/orangehrmLeavePlugin/Mail/Processor/LeaveAllocateEmailProcessor.php
@@ -27,6 +27,8 @@ use OrangeHRM\Leave\Event\LeaveAllocate;
 use OrangeHRM\Leave\Mail\Recipient;
 use OrangeHRM\Leave\Traits\Service\LeaveRequestServiceTrait;
 use OrangeHRM\Pim\Traits\Service\EmployeeServiceTrait;
+use OrangeHRM\Framework\Routing\UrlGenerator;
+use OrangeHRM\Framework\Services;
 
 class LeaveAllocateEmailProcessor extends AbstractLeaveEmailProcessor implements MailProcessor
 {
@@ -74,6 +76,14 @@ class LeaveAllocateEmailProcessor extends AbstractLeaveEmailProcessor implements
         $replacements['leaveDetails'] = $this->getLeaveDetailsByDetailedLeaves($detailedLeaves);
         $leaveRequestId = $event->getDetailedLeaveRequest()->getLeaveRequest()->getId();
         $replacements['leaveRequestComments'] = $this->getLeaveRequestComments($leaveRequestId);
+
+        /** @var UrlGenerator $urlGenerator */
+        $urlGenerator = $this->getContainer()->get(Services::URL_GENERATOR);
+        $replacements['leaveRequestLink'] = $urlGenerator->generate(
+            'leave_view_leave_request',
+            ['id' => $leaveRequestId],
+            UrlGenerator::ABSOLUTE_URL
+        );
 
         return $replacements;
     }

--- a/src/plugins/orangehrmLeavePlugin/Mail/templates/en_US/apply/leaveApplicationBody.html.twig
+++ b/src/plugins/orangehrmLeavePlugin/Mail/templates/en_US/apply/leaveApplicationBody.html.twig
@@ -39,6 +39,6 @@
     </table>
 {% endif %}
 <p>You received this email, as you are assigned as supervisor for {{ performerFirstName }}.</p>
-<p>Please login to OrangeHRM, and either approve or reject from Leave List.</p>
+<p>Please review the leave request <a href="{{ leaveRequestLink }}">here</a>.</p>
 <p>Thank you.</p>
 <p>This is an automated notification.</p>


### PR DESCRIPTION
## Summary
- update supervisor notification template with a link to the leave request
- generate `leaveRequestLink` URL in `LeaveAllocateEmailProcessor`

## Testing
- `composer install` *(fails: missing PHP extensions and blocked network)*

------
https://chatgpt.com/codex/tasks/task_b_6881a489ac6883298b9594d9128b7281